### PR TITLE
Fix for modal empty footer when no buttons are provided

### DIFF
--- a/src/components/Modal/Modal.spec.js
+++ b/src/components/Modal/Modal.spec.js
@@ -7,7 +7,7 @@ describe('Modal', () => {
 	// Add specific tests for ui-spirit related functions
 	describe('spirit interaction', () => {
 		it('respects isOpen in controlled mode', () => {
-			const wrapper = shallow(<Modal isOpen />);
+			const wrapper = shallow(<Modal isOpen buttons={[]} />);
 
 			// Mock the spirit:
 			const spirit = {

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -43,7 +43,9 @@ class Modal extends Component {
 			spirit.onclosed = this.props.onClosed;
 			spirit.onopen = this.onOpen;
 			spirit.onopened = this.props.onOpened;
-			spirit.buttons(this.props.buttons);
+			if (this.props.buttons) {
+				spirit.buttons(this.props.buttons);
+			}
 		});
 	}
 
@@ -82,8 +84,7 @@ Modal.defaultProps = {
 	onClosed: noop,
 	onOpen: noop,
 	onOpened: noop,
-	title: 'Modal',
-	buttons: []
+	title: 'Modal'
 };
 
 export default Modal;

--- a/src/stories/Modal.js
+++ b/src/stories/Modal.js
@@ -28,7 +28,6 @@ stories.addWithInfo(
 				onOpened={action('onOpened')}
 				onClose={action('onClose')}
 				onClosed={action('onClosed')}
-				buttons={buttons}
 			>
 				<main data-ts="Main">
 					<h1>A Modal Example</h1>
@@ -40,6 +39,45 @@ stories.addWithInfo(
 					</p>
 				</main>
 
+			</Modal>
+		);
+	},
+	{ inline: true }
+);
+
+stories.addWithInfo(
+	'Controlled mode w/ buttons',
+	`In controlled mode the Modal will respect the isOpen attribute at all times.
+	Use the onClose callback to toggle the flag.`,
+	() => {
+		const buttons = [
+			{
+				label: text('button_title', 'Button title'),
+				type: text('button_class', 'ts-primary'),
+				onclick() {
+					action('onClick');
+				}
+			}
+		];
+		return (
+			<Modal
+				title={text('title', 'Fullscreen Modal demo')}
+				isOpen={boolean('isOpen', false)}
+				onOpen={action('onOpen')}
+				onOpened={action('onOpened')}
+				onClose={action('onClose')}
+				onClosed={action('onClosed')}
+				buttons={buttons}
+			>
+				<main data-ts="Main">
+					<h1>A Modal Example</h1>
+					<p>…</p>
+					<p>
+						<button onClick={action('onClose')} className="ts-primary">
+							<span>Close the Modal</span>
+						</button>
+					</p>
+				</main>
 			</Modal>
 		);
 	},

--- a/src/stories/__tests__/__snapshots__/Storybook.spec.js.snap
+++ b/src/stories/__tests__/__snapshots__/Storybook.spec.js.snap
@@ -179,6 +179,41 @@ exports[`Modal Controlled mode 1`] = `
 </portal>
 `;
 
+exports[`Modal Controlled mode w/ buttons 1`] = `
+<portal>
+  <dialog
+    data-ts="Modal"
+    data-ts.open={false}
+    data-ts.title="Fullscreen Modal demo"
+  >
+    <div
+      data-ts="Panel"
+    >
+      <main
+        data-ts="Main"
+      >
+        <h1>
+          A Modal Example
+        </h1>
+        <p>
+          …
+        </p>
+        <p>
+          <button
+            className="ts-primary"
+            onClick={[Function]}
+          >
+            <span>
+              Close the Modal
+            </span>
+          </button>
+        </p>
+      </main>
+    </div>
+  </dialog>
+</portal>
+`;
+
 exports[`Note Basic usage 1`] = `null`;
 
 exports[`StatusBar Hide bar 1`] = `null`;


### PR DESCRIPTION
By removing the buttons default value, it is now possible to have a
modal without an empty footer in cases where no buttons are needed.