### PR TITLE
docs(README): Add a section on usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ $ npm install react-tradeshift-ui
 
 *Note:* Requires [Tradeshift ui](http://ui.tradeshift.com/#getstarted/) explicitly loaded on your page.
 
+## Usage
+
+Import and use the component(s).
+```javascript
+import { Footer, TsLogo } from 'react-tradeshift-ui';
+```
+
 ## Development
 Development with minimal setup via [Storybook](https://github.com/storybooks/storybook) and
 [react-scripts](https://github.com/facebookincubator/create-react-app).


### PR DESCRIPTION
@wejendorp 

We never explicitly state how to use this, so let's do that. 

Also, is what I'm adding correct? With version 1.4.0, when importing I have to use
```javascript
import { Footer } from 'react-tradeshift-ui/dist/components.js';
```
