### PR TITLE
chore: update module field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-tradeshift-ui",
   "version": "0.0.0-semantically-released",
   "main": "dist/components.js",
-  "module": "src/components/index.js",
+  "module": "dist/components.js",
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {
     "build": "webpack",


### PR DESCRIPTION
@wejendorp 

The current main and module fields are as follows:
```json
"main": "dist/components.js",
"module": "src/components/index.js",
```

Because of this, I have to specify a file when importing the library, like so: 
```javascript
import { Footer } from 'react-tradeshift-ui/dist/components.js';
```

If we change the module field to match the main field, I don't need to do that, and can import the library without specifying a file: 
```javascript
import { Footer } from 'react-tradeshift-ui';
```

