### PR TITLE
fix Buttons bug for single or invalid child

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13625,11 +13625,6 @@
       "dev": true,
       "optional": true
     },
-    "nanoid": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.3.tgz",
-      "integrity": "sha512-SbgVmGjEUAR/rYdAM0p0TCdKtJILZeYk3JavV2cmNVmIeR0SaKDudLRk58au6gpJqyFM9qz8ufEsS91D7RZyYA=="
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -21902,14 +21897,6 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
-    },
-    "shortid": {
-      "version": "2.2.15",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
-      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
-      "requires": {
-        "nanoid": "^2.1.0"
-      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -85,8 +85,7 @@
     "@types/classnames": "2.2.8",
     "classnames": "^2.2.6",
     "prop-types": "^15.7.2",
-    "react-portal": "^4.2.0",
-    "shortid": "^2.2.15"
+    "react-portal": "^4.2.0"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/src/components/Buttons/Buttons.spec.js
+++ b/src/components/Buttons/Buttons.spec.js
@@ -1,21 +1,11 @@
 import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
-import ShortID from 'shortid';
 import Buttons from '.';
 
 configure({ adapter: new Adapter() });
 
 describe('Buttons', () => {
-	beforeEach(() => {
-		jest
-			.spyOn(ShortID, 'generate')
-			.mockReturnValueOnce('short_id_1')
-			.mockReturnValueOnce('short_id_2')
-			.mockReturnValueOnce('short_id_3')
-			.mockReturnValueOnce('short_id_4');
-	});
-
 	it('should render correctly', () => {
 		const wrapper = shallow(
 			<Buttons>

--- a/src/components/Buttons/__snapshots__/Buttons.spec.js.snap
+++ b/src/components/Buttons/__snapshots__/Buttons.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Buttons should render correctly 1`] = `
   data-ts="Buttons"
 >
   <li
-    key="short_id_1"
+    key=".0"
   >
     <button
       type="button"
@@ -16,7 +16,7 @@ exports[`Buttons should render correctly 1`] = `
     </button>
   </li>
   <li
-    key="short_id_2"
+    key=".1"
   >
     <button
       type="button"

--- a/src/components/Buttons/index.js
+++ b/src/components/Buttons/index.js
@@ -1,13 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import ShortID from 'shortid';
 
 const Buttons = ({ children, ...props }) => {
 	return (
 		<menu data-ts="Buttons" {...props}>
-			{children.map(child => (
-				<li key={ShortID.generate()}>{child}</li>
-			))}
+			{React.Children.map(children, child =>
+				React.isValidElement(child) ? <li>{child}</li> : null
+			)}
 		</menu>
 	);
 };


### PR DESCRIPTION
This commit fixes bug related to either passing a single node as `children` or passing a child that is not a valid react element