### PR TITLE
fix(components): fix Aside tabs

### DIFF
--- a/src/components/Aside/index.js
+++ b/src/components/Aside/index.js
@@ -2,13 +2,23 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Portal } from 'react-portal';
 
-const noop = () => {};
+const noop = () => { };
 
 class Aside extends Component {
 	static wrapContent(nodes) {
 		const children = React.Children.toArray(nodes);
 		const wrappedTabs = children.every(node => node.props['data-ts'] === 'Panel');
-		return nodes && wrappedTabs ? nodes : <div data-ts="Panel">{nodes}</div>;
+		if (nodes && wrappedTabs) {
+			if (children.length === 1) {
+				return nodes;
+			}
+			else {
+				return <div data-ts="Panels">{nodes}</div>;
+			}
+		}
+		else {
+			return <div data-ts="Panel">{nodes}</div>;
+		}
 	}
 
 	constructor(props) {

--- a/src/stories/__tests__/__snapshots__/Storybook.spec.js.snap
+++ b/src/stories/__tests__/__snapshots__/Storybook.spec.js.snap
@@ -9,16 +9,20 @@ exports[`Aside Aside tabs 1`] = `
     data-ts.title="Aside demo"
   >
     <div
-      data-ts="Panel"
-      data-ts.label="tab 0"
+      data-ts="Panels"
     >
-      tab 0 content
-    </div>
-    <div
-      data-ts="Panel"
-      data-ts.label="tab 1"
-    >
-      tab 1 content
+      <div
+        data-ts="Panel"
+        data-ts.label="tab 0"
+      >
+        tab 0 content
+      </div>
+      <div
+        data-ts="Panel"
+        data-ts.label="tab 1"
+      >
+        tab 1 content
+      </div>
     </div>
   </aside>
 </portal>


### PR DESCRIPTION
fix(components): fix Aside tabs

The current implementation for rendering aside tabs doesn't work due to the fact that the div that should incorporate them is missing.

<img width="1334" alt="Screenshot 2020-07-07 at 16 30 13" src="https://user-images.githubusercontent.com/28860247/86790325-fa834b00-c070-11ea-8750-59ca88f874df.png">
