### PR TITLE
Make aside's autofocus configurable

### DIFF
--- a/src/components/Aside/index.js
+++ b/src/components/Aside/index.js
@@ -54,9 +54,10 @@ class Aside extends Component {
 	}
 
 	render() {
-		const { isLoading, loadingMessage, title, isOpen, className } = this.props;
+		const { autofocus, isLoading, loadingMessage, title, isOpen, className } = this.props;
 		const busyMessage = isLoading ? loadingMessage : '';
 		const asideProps = {
+			'data-ts.autofocus': autofocus,
 			'data-ts.title': title,
 			'data-ts.open': isOpen,
 			'data-ts.busy': busyMessage,
@@ -79,6 +80,7 @@ class Aside extends Component {
 
 Aside.propTypes = {
 	children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+	autofocus: PropTypes.bool,
 	isLoading: PropTypes.bool,
 	isOpen: PropTypes.bool,
 	loadingMessage: PropTypes.string,
@@ -92,6 +94,7 @@ Aside.propTypes = {
 
 Aside.defaultProps = {
 	children: null,
+	autofocus: true,
 	isLoading: false,
 	isOpen: undefined,
 	loadingMessage: 'Loading...',

--- a/src/stories/__tests__/__snapshots__/Storybook.spec.js.snap
+++ b/src/stories/__tests__/__snapshots__/Storybook.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Aside Aside tabs 1`] = `
 <portal>
   <aside
     data-ts="Aside"
+    data-ts.autofocus={true}
     data-ts.busy=""
     data-ts.open={false}
     data-ts.title="Aside demo"
@@ -33,6 +34,7 @@ exports[`Aside Controlled mode 1`] = `
   <aside
     className="aside-class"
     data-ts="Aside"
+    data-ts.autofocus={true}
     data-ts.busy=""
     data-ts.open={false}
     data-ts.title="Aside demo"


### PR DESCRIPTION
The `Aside` component has `autofocus` enabled by default, but some times that's not the desired behavior as it leads to ugly/unnecessary styling on the first form element that the aside can set the focus on, this is especially problematic for selects(see attached photo).

This PR aims to make the autofocus feature configurable.

<img width="321" alt="autofocus-issue" src="https://user-images.githubusercontent.com/2471272/107631062-1b49f980-6c6d-11eb-9c86-437476a8c6b0.png">
